### PR TITLE
feat: #500 Add EVU2 and SmartGrid status sensors

### DIFF
--- a/custom_components/luxtronik/binary_sensor_entities_predefined.py
+++ b/custom_components/luxtronik/binary_sensor_entities_predefined.py
@@ -10,9 +10,13 @@ BINARY_SENSORS: list[LuxtronikBinarySensorEntityDescription] = [
     LuxtronikBinarySensorEntityDescription(
         key=SensorKey.EVU_UNLOCKED,
         luxtronik_key=LC.C0031_EVU_UNLOCKED,
-        icon="mdi:lock",
-        device_class=BinarySensorDeviceClass.LOCK,
+        icon="mdi:transmission-tower",
         visibility=LV.V0121_EVU_LOCKED,
+    ),
+    LuxtronikBinarySensorEntityDescription(
+        key=SensorKey.EVU2,
+        luxtronik_key=LC.C0185_EVU2,
+        icon="mdi:transmission-tower",
     ),
     LuxtronikBinarySensorEntityDescription(
         key=SensorKey.COMPRESSOR,

--- a/custom_components/luxtronik/const.py
+++ b/custom_components/luxtronik/const.py
@@ -157,7 +157,9 @@ class LuxSmartGridStatus(StrEnum):
     locked: Final = "evu_locked"  # EVU=1, EVU2=0 - Status 1 - EVU lock
     reduced: Final = "reduced_operation"  # EVU=0, EVU2=0 - Status 2 - Reduced operation
     normal: Final = "normal_operation"  # EVU=0, EVU2=1 - Status 3 - Normal operation
-    increased: Final = "increased_operation"  # EVU=1, EVU2=1 - Status 4 - Increased operation
+    increased: Final = (
+        "increased_operation"  # EVU=1, EVU2=1 - Status 4 - Increased operation
+    )
 
 
 class LuxStatus1Option(StrEnum):

--- a/custom_components/luxtronik/const.py
+++ b/custom_components/luxtronik/const.py
@@ -151,6 +151,15 @@ class LuxMode(StrEnum):
     holidays: Final = "Holidays"
 
 
+class LuxSmartGridStatus(StrEnum):
+    """SmartGrid status based on EVU and EVU2 inputs."""
+
+    locked: Final = "evu_locked"  # EVU=1, EVU2=0 - Status 1 - EVU lock
+    reduced: Final = "reduced_operation"  # EVU=0, EVU2=0 - Status 2 - Reduced operation
+    normal: Final = "normal_operation"  # EVU=0, EVU2=1 - Status 3 - Normal operation
+    increased: Final = "increased_operation"  # EVU=1, EVU2=1 - Status 4 - Increased operation
+
+
 class LuxStatus1Option(StrEnum):
     """LuxStatus1 option defrost etc."""
 
@@ -269,6 +278,13 @@ LUX_STATE_ICON_MAP_COOL: Final[dict[StateType | date | datetime | Decimal, str]]
     LuxOperationMode.defrost.value: "mdi:car-defrost-rear",
     LuxOperationMode.no_request.value: "mdi:snowflake-off",
     LuxOperationMode.cooling.value: "mdi:air-conditioner",
+}
+
+LUX_SMART_GRID_ICON_MAP: Final[dict[StateType | date | datetime | Decimal, str]] = {
+    LuxSmartGridStatus.locked.value: "mdi:cancel",  # EVU lock - Blocked
+    LuxSmartGridStatus.reduced.value: "mdi:arrow-down-circle",  # Reduced operation
+    LuxSmartGridStatus.normal.value: "mdi:check-circle",  # Normal operation
+    LuxSmartGridStatus.increased.value: "mdi:arrow-up-circle",  # Increased operation
 }
 
 LUX_MODELS_ALPHA_INNOTEC = ["LWP", "LWV", "MSW", "SWC", "SWP"]
@@ -591,6 +607,7 @@ class LuxCalculation(StrEnum):
     C0180_HIGH_PRESSURE: Final = "calculations.ID_WEB_LIN_HD"
     C0181_LOW_PRESSURE: Final = "calculations.ID_WEB_LIN_ND"
     C0182_COMPRESSOR_HEATER: Final = "calculations.ID_WEB_LIN_VDH_out"
+    C0185_EVU2: Final = "calculations.ID_WEB_HZIO_EVU2"
     # C0187_CURRENT_OUTPUT: Final = "calculations.ID_WEB_SEC_Qh_Soll"
     # C0188_CURRENT_OUTPUT: Final = "calculations.ID_WEB_SEC_Qh_Ist"
     C0204_HEAT_SOURCE_INPUT_TEMPERATURE: Final = "calculations.ID_WEB_Temperatur_TWE"
@@ -825,6 +842,8 @@ class SensorKey(StrEnum):
     )
     SOLAR_PUMP_MAX_TEMPERATURE_COLLECTOR = "solar_pump_max_temperature_collector"
     EVU_UNLOCKED = "evu_unlocked"
+    EVU2 = "evu2"
+    SMART_GRID_STATUS = "smart_grid_status"
     COMPRESSOR = "compressor"
     COMPRESSOR2 = "compressor2"
     PUMP_FLOW = "pump_flow"

--- a/custom_components/luxtronik/sensor.py
+++ b/custom_components/luxtronik/sensor.py
@@ -217,10 +217,16 @@ class LuxtronikStatusSensorEntity(LuxtronikSensorEntity, SensorEntity):
         if self.entity_description.key == SensorKey.SMART_GRID_STATUS:
             # Check if SmartGrid is enabled (P1030)
             from .const import LuxParameter as LP
+
             smartgrid_enabled = self._get_value(LP.P1030_SMART_GRID_SWITCH)
 
             # If SmartGrid is disabled, set sensor to unavailable
-            if not smartgrid_enabled or smartgrid_enabled in [False, 0, "false", "False"]:
+            if not smartgrid_enabled or smartgrid_enabled in [
+                False,
+                0,
+                "false",
+                "False",
+            ]:
                 self._attr_available = False
                 self._attr_native_value = None
             else:
@@ -239,17 +245,28 @@ class LuxtronikStatusSensorEntity(LuxtronikSensorEntity, SensorEntity):
                 # EVU=0, EVU2=1 → Status 3 (normal operation)
                 # EVU=1, EVU2=1 → Status 4 (increased operation)
                 if evu_on and not evu2_on:
-                    self._attr_native_value = LuxSmartGridStatus.locked.value  # Status 1
+                    self._attr_native_value = (
+                        LuxSmartGridStatus.locked.value
+                    )  # Status 1
                 elif not evu_on and not evu2_on:
-                    self._attr_native_value = LuxSmartGridStatus.reduced.value  # Status 2
+                    self._attr_native_value = (
+                        LuxSmartGridStatus.reduced.value
+                    )  # Status 2
                 elif not evu_on and evu2_on:
-                    self._attr_native_value = LuxSmartGridStatus.normal.value  # Status 3
+                    self._attr_native_value = (
+                        LuxSmartGridStatus.normal.value
+                    )  # Status 3
                 else:  # evu_on and evu2_on
-                    self._attr_native_value = LuxSmartGridStatus.increased.value  # Status 4
+                    self._attr_native_value = (
+                        LuxSmartGridStatus.increased.value
+                    )  # Status 4
 
                 # Set icon based on current state
                 descr = self.entity_description
-                if descr.icon_by_state and self._attr_native_value in descr.icon_by_state:
+                if (
+                    descr.icon_by_state
+                    and self._attr_native_value in descr.icon_by_state
+                ):
                     self._attr_icon = descr.icon_by_state.get(self._attr_native_value)
                 elif descr.icon:
                     self._attr_icon = descr.icon

--- a/custom_components/luxtronik/sensor.py
+++ b/custom_components/luxtronik/sensor.py
@@ -27,9 +27,11 @@ from .const import (
     DeviceKey,
     LuxCalculation as LC,
     LuxOperationMode,
+    LuxSmartGridStatus,
     LuxStatus1Option,
     LuxStatus3Option,
     SensorAttrKey as SA,
+    SensorKey,
 )
 from .coordinator import LuxtronikCoordinator, LuxtronikCoordinatorData
 from .evu_helper import LuxtronikEVUTracker
@@ -84,7 +86,10 @@ async def async_setup_entry(
             for description in SENSORS_STATUS
             if (
                 coordinator.entity_active(description)
-                and key_exists(coordinator.data, description.luxtronik_key)
+                and (
+                    description.luxtronik_key == LC.UNSET
+                    or key_exists(coordinator.data, description.luxtronik_key)
+                )
             )
         ],
         True,
@@ -208,7 +213,54 @@ class LuxtronikStatusSensorEntity(LuxtronikSensorEntity, SensorEntity):
         self, data: LuxtronikCoordinatorData | None = None
     ) -> None:
         """Handle updated data from the coordinator."""
-        super()._handle_coordinator_update(data)
+        # Calculate SmartGrid Status from EVU and EVU2 inputs
+        if self.entity_description.key == SensorKey.SMART_GRID_STATUS:
+            # Check if SmartGrid is enabled (P1030)
+            from .const import LuxParameter as LP
+            smartgrid_enabled = self._get_value(LP.P1030_SMART_GRID_SWITCH)
+
+            # If SmartGrid is disabled, set sensor to unavailable
+            if not smartgrid_enabled or smartgrid_enabled in [False, 0, "false", "False"]:
+                self._attr_available = False
+                self._attr_native_value = None
+            else:
+                self._attr_available = True
+
+                evu = self._get_value(LC.C0031_EVU_UNLOCKED)
+                evu2 = self._get_value(LC.C0185_EVU2)
+
+                # Convert to boolean (handle True/False/1/0/"true"/"false")
+                evu_on = evu in [True, 1, "true", "True"]
+                evu2_on = evu2 in [True, 1, "true", "True"]
+
+                # Determine SmartGrid status based on EVU and EVU2 inputs
+                # EVU=0, EVU2=0 → Status 2 (reduced operation)
+                # EVU=1, EVU2=0 → Status 1 (EVU locked)
+                # EVU=0, EVU2=1 → Status 3 (normal operation)
+                # EVU=1, EVU2=1 → Status 4 (increased operation)
+                if evu_on and not evu2_on:
+                    self._attr_native_value = LuxSmartGridStatus.locked.value  # Status 1
+                elif not evu_on and not evu2_on:
+                    self._attr_native_value = LuxSmartGridStatus.reduced.value  # Status 2
+                elif not evu_on and evu2_on:
+                    self._attr_native_value = LuxSmartGridStatus.normal.value  # Status 3
+                else:  # evu_on and evu2_on
+                    self._attr_native_value = LuxSmartGridStatus.increased.value  # Status 4
+
+                # Set icon based on current state
+                descr = self.entity_description
+                if descr.icon_by_state and self._attr_native_value in descr.icon_by_state:
+                    self._attr_icon = descr.icon_by_state.get(self._attr_native_value)
+                elif descr.icon:
+                    self._attr_icon = descr.icon
+
+            # Don't call super() to avoid setting value to None (luxtronik_key=UNSET)
+            self._enrich_extra_attributes()
+            self.async_write_ha_state()
+        else:
+            # For normal status sensors, use the parent's update logic
+            super()._handle_coordinator_update(data)
+
         self._evu_tracker.update(self._attr_native_value)
 
         if self._attr_native_value is None or self._last_state is None:

--- a/custom_components/luxtronik/sensor_entities_predefined.py
+++ b/custom_components/luxtronik/sensor_entities_predefined.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
 from homeassistant.helpers.entity import EntityCategory
 
 from .const import (
+    LUX_SMART_GRID_ICON_MAP,
     LUX_STATE_ICON_MAP,
     SECOND_TO_HOUR_FACTOR,
     UPDATE_INTERVAL_NORMAL,
@@ -23,6 +24,7 @@ from .const import (
     LuxCalculation as LC,
     LuxOperationMode,
     LuxParameter as LP,
+    LuxSmartGridStatus,
     LuxStatus1Option,
     LuxStatus3Option,
     LuxSwitchoffReason,
@@ -54,6 +56,14 @@ SENSORS_STATUS: list[descr] = [
             attr(SA.EVU_DAYS, LC.UNSET, None, True),
         ),
         options=[e.value for e in LuxOperationMode],
+        update_interval=UPDATE_INTERVAL_NORMAL,
+    ),
+    descr(
+        key=SensorKey.SMART_GRID_STATUS,
+        luxtronik_key=LC.UNSET,  # Calculated from EVU and EVU2 inputs
+        icon_by_state=LUX_SMART_GRID_ICON_MAP,
+        device_class=SensorDeviceClass.ENUM,
+        options=[e.value for e in LuxSmartGridStatus],
         update_interval=UPDATE_INTERVAL_NORMAL,
     ),
 ]

--- a/custom_components/luxtronik/translations/cs.json
+++ b/custom_components/luxtronik/translations/cs.json
@@ -4,6 +4,9 @@
             "evu_unlocked": {
                 "name": "HDO"
             },
+            "evu2": {
+                "name": "EVU2"
+            },
             "compressor": {
                 "name": "Kompresor"
             },
@@ -268,6 +271,15 @@
                             "evu_in": "HDO blokovace za {evu_time} minut."
                         }
                     }
+                }
+            },
+            "smart_grid_status": {
+                "name": "Stav SmartGrid",
+                "state": {
+                    "evu_locked": "Blokováno EVU",
+                    "reduced_operation": "Snížený provoz",
+                    "normal_operation": "Normální provoz",
+                    "increased_operation": "Zvýšený provoz"
                 }
             },
             "error_reason": {

--- a/custom_components/luxtronik/translations/de.json
+++ b/custom_components/luxtronik/translations/de.json
@@ -4,6 +4,9 @@
             "evu_unlocked": {
                 "name": "Sperrzeit Freigabe"
             },
+            "evu2": {
+                "name": "EVU2"
+            },
             "compressor": {
                 "name": "Verdichter"
             },
@@ -268,6 +271,15 @@
                             "evu_in": "Netzsperre in {evu_time} Minuten."
                         }
                     }
+                }
+            },
+            "smart_grid_status": {
+                "name": "SmartGrid Status",
+                "state": {
+                    "evu_locked": "EVU-Sperre",
+                    "reduced_operation": "abgesenkte Betriebsweise",
+                    "normal_operation": "Normalbetrieb",
+                    "increased_operation": "erhöhte Betriebsweise"
                 }
             },
             "error_reason": {

--- a/custom_components/luxtronik/translations/en.json
+++ b/custom_components/luxtronik/translations/en.json
@@ -4,6 +4,9 @@
             "evu_unlocked": {
                 "name": "Locktime"
             },
+            "evu2": {
+                "name": "EVU2"
+            },
             "compressor": {
                 "name": "Compressor"
             },
@@ -271,6 +274,15 @@
                             "evu_in": "Locktime in {evu_time} minutes."
                         }
                     }
+                }
+            },
+            "smart_grid_status": {
+                "name": "SmartGrid Status",
+                "state": {
+                    "evu_locked": "EVU locked",
+                    "reduced_operation": "Reduced operation",
+                    "normal_operation": "Normal operation",
+                    "increased_operation": "Increased operation"
                 }
             },
             "error_reason": {

--- a/custom_components/luxtronik/translations/nl.json
+++ b/custom_components/luxtronik/translations/nl.json
@@ -4,6 +4,9 @@
             "evu_unlocked": {
                 "name": "Tijdvrijgave blokkeren"
             },
+            "evu2": {
+                "name": "EVU2"
+            },
             "compressor": {
                 "name": "Compressor"
             },
@@ -265,6 +268,15 @@
                             "evu_in": "Netwerksluiting over {evu_time} minuten."
                         }
                     }
+                }
+            },
+            "smart_grid_status": {
+                "name": "SmartGrid Status",
+                "state": {
+                    "evu_locked": "EVU geblokkeerd",
+                    "reduced_operation": "Verminderde werking",
+                    "normal_operation": "Normale werking",
+                    "increased_operation": "Verhoogde werking"
                 }
             },
             "error_reason": {

--- a/custom_components/luxtronik/translations/pl.json
+++ b/custom_components/luxtronik/translations/pl.json
@@ -4,6 +4,9 @@
             "evu_unlocked": {
                 "name": "Czas blokady"
             },
+            "evu2": {
+                "name": "EVU2"
+            },
             "compressor": {
                 "name": "Kompresor"
             },
@@ -259,6 +262,15 @@
                             "evu_in": "Czas blokady za {evu_time} minut."
                         }
                     }
+                }
+            },
+            "smart_grid_status": {
+                "name": "Status SmartGrid",
+                "state": {
+                    "evu_locked": "Zablokowane EVU",
+                    "reduced_operation": "Praca obniżona",
+                    "normal_operation": "Praca normalna",
+                    "increased_operation": "Praca zwiększona"
                 }
             },
             "error_reason": {


### PR DESCRIPTION
  - Add EVU2 binary sensor (calculation ID 185: ID_WEB_HZIO_EVU2)
  - Add SmartGrid status sensor with 4 states based on EVU+EVU2
  - SmartGrid status: locked, reduced, normal, increased operation
  - Dynamic state-based icons for SmartGrid status
  - Sensor becomes unavailable when SmartGrid switch is disabled
  - Add translations for DE, EN, CS, NL, PL